### PR TITLE
Fixed error when getting single price ticker with market filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,10 +406,26 @@ for(int i = 0; i < candles.length(); i ++) {
 ```
 </details>
 
-#### Get price ticker
+#### Get single price ticker
 ```java
-// options: market
-JSONArray response = bitvavo.tickerPrice(new JSONObject());
+// option market
+JSONObject response = bitvavo.tickerPrice(new JSONObject("{ market: BTC-EUR }"));
+System.out.println(response.toString(2));
+```
+<details>
+ <summary>View Response</summary>
+
+```java
+{
+  "market": "BTC-EUR",
+  "price": "6812.7"
+}
+```
+</details>
+
+#### Get all price tickers
+```java
+JSONArray response = bitvavo.tickerPrices();
 for(int i = 0; i < response.length(); i ++) {
   System.out.println(response.getJSONObject(i).toString(2));
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://bitvavo.com"><img src="https://bitvavo.com/media/images/logo/bitvavoGeneral.svg" width="600" title="Bitvavo Logo"></a>
+  <a href="https://bitvavo.com"><img src="https://bitvavo.com/assets/img/logo/logo-dark.svg?v=48ae6fe7" width="600" title="Bitvavo Logo"></a>
 </p>
 
 # Java Bitvavo Api

--- a/src/main/java/com/bitvavo/api/Bitvavo.java
+++ b/src/main/java/com/bitvavo/api/Bitvavo.java
@@ -442,13 +442,21 @@ public class Bitvavo {
   }
 
   /**
-   * Returns the ticker price
-   * @param options optional parameters: market
+   * Returns a single ticker price
+   * @param options JSONObject with the 'market' filter parameter
+   * @return JSONObject response
+   */
+  public JSONObject tickerPrice(JSONObject options) {
+    String postfix = createPostfix(options);
+    return publicRequest(base + "/ticker/price" + postfix, "GET", new JSONObject());
+  }
+
+  /**
+   * Returns the ticker prices
    * @return JSONArray response, get individual prices by iterating over array: response.getJSONObject(index)
    */
-  public JSONArray tickerPrice(JSONObject options) {
-    String postfix = createPostfix(options);
-    return publicRequestArray((base + "/ticker/price" + postfix), "GET", new JSONObject());
+  public JSONArray tickerPrices() {
+    return publicRequestArray(base + "/ticker/price", "GET", new JSONObject());
   }
 
   /**


### PR DESCRIPTION
I ran in to an error where I wanted to only get the Bitcoin price.
The initial code did not work: 
```java
JSONArray response = bitvavo.tickerPrice(new JSONObject("{ market: BTC-EUR }"));
```
This resulted in the following error:
```
A JSONArray text must start with '[' at 1 [character 2 line 1]
```

This was caused by trying to parse the single returned JSON object to a String.

I propose a new method to get a single price ticker that returns a JSONObject. The original method can be altered to not need a JSONObject parameter.

Please see my proposed solution, I'd love to hear your thoughts on it!
