### PR TITLE
README: Fix broken logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://bitvavo.com"><img src="https://bitvavo.com/media/images/logo/bitvavoGeneral.svg" width="600" title="Bitvavo Logo"></a>
+  <a href="https://bitvavo.com"><img src="https://bitvavo.com/assets/img/press/logo/dark/svg/full.svg" width="600" title="Bitvavo Logo"></a>
 </p>
 
 # Java Bitvavo Api


### PR DESCRIPTION
The current logo in the README is broken, because the link to the img
404s:
https://bitvavo.com/media/images/logo/bitvavoGeneral.svg

Replaced with:
https://bitvavo.com/assets/img/press/logo/dark/svg/full.svg